### PR TITLE
Fixed Bug: Schema & Note

### DIFF
--- a/sanity/schemas/project-schema.ts
+++ b/sanity/schemas/project-schema.ts
@@ -11,7 +11,6 @@ defineField({
       {title: 'HTML', value: 'html'},
       {title: 'CSS', value: 'css'},
     ],
-    withFileName: true,
   },
 })
 

--- a/src/app/notes/[note]/page.jsx
+++ b/src/app/notes/[note]/page.jsx
@@ -36,10 +36,18 @@ export default async function note({ params }) {
           components={{
             block: {
               normal: ({children}) => (
-                <p className="mb-4 indent-4">{children}</p>,
+                <p className="mb-4 indent-4">{children}</p>
               ),
-              ul: ({children}) => <ul className="list-disc text-sky-500">{children}</ul>,
-              li: ({children}) => <li className="list-disc text-sky-500">{children}</li>,
+            },
+            list: {
+              bullet: ({children}) => (
+                <ul className="list-disc text-sky-500">{children}</ul>
+              ),
+            },
+            listItem: {
+              bullet: ({children}) => ( 
+                <li className="list-disc text-sky-500">{children}</li>
+              ),
             },
           }}
         />    


### PR DESCRIPTION
project-schema.ts: removed withFileName bc it is no longer necessary.

/src/app/notes/[note]/page.jsx: fixed indentation and syntax error for accessing the <li> & <ul> elements. Styling works now.